### PR TITLE
Windows : update for asciidoc libs; set GRAPHVIZ_DOT to the relative …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <cobertura.version>2.7</cobertura.version>
 
         <!-- jQAssistant and asciidoctor -->
-        <jqassistant.version>1.3.0</jqassistant.version>
+        <jqassistant.version>1.2.0</jqassistant.version>
         <asciidoctor.version>1.5.5</asciidoctor.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
         <cobertura.version>2.7</cobertura.version>
 
         <!-- jQAssistant and asciidoctor -->
-        <jqassistant.version>1.2.0</jqassistant.version>
-        <asciidoctor.version>1.5.3</asciidoctor.version>
+        <jqassistant.version>1.3.0</jqassistant.version>
+        <asciidoctor.version>1.5.5</asciidoctor.version>
     </properties>
 
     <dependencyManagement>
@@ -462,7 +462,7 @@
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-diagram</artifactId>
-                        <version>1.3.1</version>
+                        <version>1.5.4</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
graphs generation fails for asciidoc "Could not find GraphViz 'dot' tool" see https://github.com/asciidoctor/asciidoctorj/issues/462